### PR TITLE
Entry numaraları ile ilgili ufak bir hata düzeltmesi

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,9 +50,9 @@
 
 		var $pageMatcher = location.href.match(/[&|\?]p=([0-9]+)&?/i);
 
-	  var $pagers      = $(document.getElementsByClassName('pager'));
-	  var $pagerEntry  = $pagers[$pagers.length-1];
-	  var $pagerPage   = parseInt($pagerEntry.getAttribute('data-currentpage'));
+		var $pagers      = $(document.getElementsByClassName('pager'));
+		var $pagerEntry  = $pagers[$pagers.length-1];
+		var $pagerPage   = parseInt($pagerEntry.getAttribute('data-currentpage'));
 
 		if ( $pageMatcher )
 		{

--- a/script.js
+++ b/script.js
@@ -50,10 +50,19 @@
 
 		var $pageMatcher = location.href.match(/[&|\?]p=([0-9]+)&?/i);
 
+	  var $pagers      = $(document.getElementsByClassName('pager'));
+	  var $pagerEntry  = $pagers[$pagers.length-1];
+	  var $pagerPage   = parseInt($pagerEntry.getAttribute('data-currentpage'));
+
 		if ( $pageMatcher )
 		{
 			$currentPage = parseInt($pageMatcher[1]);
 		}
+		else if( $pagerPage )
+		{
+			$currentPage = $pagerPage;
+		}
+
 
 		if ( $entryWrapper.length )
 		{


### PR DESCRIPTION
Merhaba, eklentiyi maintain etmeye devam ettiğiniz için çok teşekkür ederim! Şahsen her gün zevkle kullanıyorum. Entry numaralarının doğru gösterilmediği bir durum vardı, onun için küçük bir fix paylaşıyorum. Yorumlarınıza/düzenlemerinize açığım.
#55'e yorum olarak bırakılmış: İlk entrysi bugün yazılmamış başlıklarda "x entry daha" yazısı tıklanıldığında adrese `p=` yerine `focusto=` ekleniyor. Mevcut sayfa numaraları p'den geldiği için bu durumda doğru gösterilemiyor. Bu commit yine öncelikli olarak p'ye bakıyor, mevcut değilse numarayı pager'dan alıyor.
#39'da @yali4 daha önce pager kullandığından, ancak birden fazla pager olduğu durumlarda sayfa numaralarının yanlış görüntülendiğinden bahsetmiş. Bunu da en son pager'i isteyerek çözmeye çalıştım.

[https://eksisozluk.com/bob-dylan--33088?focusto=63465043](https://eksisozluk.com/bob-dylan--33088?focusto=63465043)

![ekran görüntüsü](http://i.imgur.com/MNXLHsv.png)
# hacktoberfest
